### PR TITLE
Fix issues url - remove trailing forward slash

### DIFF
--- a/source/responding-to-webhook.rst
+++ b/source/responding-to-webhook.rst
@@ -87,7 +87,7 @@ The API calls will need to be change as follows::
 Let's now think about the ``url`` in this case. Previously, you might have constructed
 the url manually as follows::
 
-   url = f"/repos/mariatta/strange-relationship/issues/"
+   url = f"/repos/mariatta/strange-relationship/issues"
 
 We do we know which repository your app was installed to?
 
@@ -114,7 +114,7 @@ Notice that the repository name is provided in the webhook, under the list of
 "repositories". So we can iterate on it and construct the url as follows::
 
     for repository in event.data['repositories']:
-        url = f"/repos/{repository['full_name'}/issues/"
+        url = f"/repos/{repository['full_name'}/issues"
 
 
 The next piece we want to figure out is what should the comment message be. For
@@ -154,7 +154,7 @@ comment::
         message = f"Thanks for installing me, @{maintainer}! (I'm a bot)."
 
         for repository in event.data["repositories_added"]:
-            url = f"/repos/{repository['full_name']}/issues/"
+            url = f"/repos/{repository['full_name']}/issues"
             response = await gh.post(
                 url,
                 data={


### PR DESCRIPTION
Thanks for the great tutorial!  

## What do these changes do?

Trailing forward slash in [GitHub issues api](https://developer.github.com/v3/issues/#create-an-issue) results in status code 400. This PR removes trailing forward slash from webhooks examples. 

## Are there changes in behavior for the user?

Copy pasted code should now work without running into `gidgethub.BadRequest: Not Found`

## Checklist

- [ ] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is `<Name> <Surname>`.
  * Please keep alphabetical order, the file is sorted by names. 
- [ ] Documentation reflects the changes
- [ ] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` (e.g. `588.bugfix`)
  * if you don't have an `issue_id` change it to the pr id after creating the PR
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: `Fix issue with non-ascii contents in doctest text files.`
